### PR TITLE
Fixed unnecessary ping

### DIFF
--- a/cogs/corona.py
+++ b/cogs/corona.py
@@ -122,7 +122,8 @@ class Coronavirus(commands.Cog):
                     channel = self.bot.get_channel(
                         int(self.bot.database.settings["corona_channel"])
                     )
-                    await channel.send("@everyone " + tweet.url())
+                    role = channel.guild.get_role(688844587288100874)
+                    await channel.send(f"{role.mention} {tweet.url()")
 
     @commands.command()
     @commands.check(is_admin)


### PR DESCRIPTION
Instead of pinging @everyone, only pings those who have the 'cov19 updates' role.